### PR TITLE
Refactor frontend script and add backend tests

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,0 +1,4 @@
+test/**
+node_modules/**
+package.json
+package-lock.json

--- a/Code.gs
+++ b/Code.gs
@@ -26,7 +26,7 @@ function include(filename) {
 }
 
 /**
- * 读取配置：角色/币种/分类映射，并根据登录邮箱尝试自动识别角色
+ * 读取配置：角色/币种/分类映射
  * 需要的工作表：
  * - Config_Roles: [role_id, role_name, email?]
  * - Config_Currency: [currency_code]
@@ -84,13 +84,8 @@ function recordTxn(payload) {
 
   const conf = getConfig();
 
-  // 若未显式选择角色且可自动识别，就用 autoRole
-  if ((!role || role === '') && conf.autoRole) {
-    role = conf.autoRole;
-  }
-
   // 基本校验
-  if (!role) throw new Error('缺少 role（未匹配到自动角色，且未选择）');
+  if (!role) throw new Error('缺少 role');
   if (!currency) throw new Error('缺少 currency');
   if (!category) throw new Error('缺少 category');
   if (!subcategory) throw new Error('缺少 subcategory');

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ role_id	role_name	password
 
 
  
+
+## 本地测试
+
+```bash
+npm test
+```
+
+以上命令会运行后端单元测试。测试文件及 Node 依赖在部署到 Google Apps Script 时会被 `.claspignore` 排除。

--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
 
       <div class="body">
 
-        <!-- Step 0: 角色（若 autoRole 存在自动跳过） -->
+        <!-- Step 0: 角色 -->
         <section class="step" data-step="0" id="step-role">
-          <div class="group" id="roleWrap">
+          <div class="group">
             <label>角色</label>
-            <div class="grid" id="gridRole"></div> <!-- 用grid替代select -->
+            <div class="grid" id="gridRole"></div>
           </div>
         </section>
 
@@ -114,155 +114,6 @@
     </div>
   </div>
 
-  <script>
-    const $ = (id)=>document.getElementById(id);
-    const state = {
-      conf:null, autoRole:false, step:0, lastStep:5,
-      sel:{ currency:'', category:'', subcategory:'' }
-    };
-
-    function setMsg(text, ok=false){
-      const el=$('msg'); el.textContent=text||''; el.className='hint ' + (ok?'ok':'err');
-    }
-
-    // 宫格渲染
-    function renderChips(container, items, getLabel=(x)=>x, selected=''){
-      container.innerHTML=''; // 清空容器
-      items.forEach(val => {
-        const div = document.createElement('div');
-        div.className = 'chip';
-        div.textContent = getLabel(val);
-        div.dataset.value = val.name;  // 角色名称
-        if (val.name === selected) div.dataset.selected = '1';
-        div.addEventListener('click', () => {
-          [...container.children].forEach(c => c.dataset.selected = '0');
-          div.dataset.selected = '1';
-          state.sel.role = val.name; // 更新选中的角色
-        }, { passive: true });
-        container.appendChild(div); // 添加按钮
-      });
-    }
-    function getSelected(container){
-      const hit=[...container.children].find(c=>c.dataset.selected==='1');
-      return hit ? hit.dataset.value : '';
-    }
-    function clearSelected(container){ [...container.children].forEach(c=>c.dataset.selected='0'); }
-
-    function showStep(n){
-      state.step=n;
-      document.querySelectorAll('.step').forEach(s=>s.classList.add('hidden'));
-      const target=document.querySelector(`.step[data-step="${n}"]`);
-      if(target) target.classList.remove('hidden');
-      $('progress').textContent=`步骤 ${Math.min(n+1,state.lastStep+1)} / ${state.lastStep+1}`;
-      $('btnPrev').disabled=(n===0);
-      $('btnNext').textContent=(n===state.lastStep)?'提交':'下一步';
-      window.scrollTo({top:0,behavior:'smooth'});
-    }
-
-    function validateStep(n){
-      if(n===0 && !state.autoRole) {
-        if (!$('role').value) { setMsg('请选择角色'); return false; }
-        return true;
-      }
-      if(n===1){
-        state.sel.currency=getSelected($('gridCurrency'));
-        if(!state.sel.currency){ setMsg('请选择货币'); return false; }
-        return true;
-      }
-      if(n===2){
-        state.sel.category=getSelected($('gridCategory'));
-        if(!state.sel.category){ setMsg('请选择大类'); return false; }
-        return true;
-      }
-      if(n===3){
-        state.sel.subcategory=getSelected($('gridSubcategory'));
-        if(!state.sel.subcategory){ setMsg('请选择细类'); return false; }
-        return true;
-      }
-      if(n===4){
-        const a=Number($('amount').value);
-        if(!(a>0)){ setMsg('金额需 > 0'); return false; }
-        return true;
-      }
-      return true;
-    }
-
-    function collectPayload(){
-      const role = state.autoRole ? state.conf.autoRole : $('role').value;
-      return {
-        role,
-        currency: state.sel.currency,
-        category: state.sel.category,
-        subcategory: state.sel.subcategory,
-        amount: Number($('amount').value),
-        note: $('note').value.trim()
-      };
-    }
-
-    function submit(){
-      const payload=collectPayload();
-      $('btnNext').disabled=true; setMsg('');
-      google.script.run.withSuccessHandler((res)=>{
-        $('btnNext').disabled=false;
-        if(res && res.ok){
-          setMsg(`已记录（行 ${res.row}）`, true);
-          $('amount').value=''; $('note').value='';
-          showStep(4); // 回到金额，方便连续记账
-        }else setMsg('提交失败');
-      }).withFailureHandler((err)=>{
-        $('btnNext').disabled=false;
-        setMsg(err && err.message ? err.message : '提交失败');
-      }).recordTxn(payload);
-    }
-
-    // 下一步/上一步
-    $('btnNext').addEventListener('click', ()=>{
-      setMsg('');
-      if(state.step===state.lastStep){
-        if(validateStep(state.step)) submit();
-        return;
-      }
-      if(validateStep(state.step)){
-        if(state.step===2){ // 选中大类后刷新细类
-          const subs=(state.conf && state.conf.categories[state.sel.category])||[];
-          renderChips($('gridSubcategory'), subs, (x)=>x, '');
-        }
-        showStep(state.step+1);
-      }
-    });
-    $('btnPrev').addEventListener('click', ()=>{ setMsg(''); if(state.step>0) showStep(state.step-1); });
-
-    // 初始化
-    google.script.run.withSuccessHandler((conf)=>{
-      state.conf=conf;
-
-      // 角色
-      if(conf.autoRole){
-        state.autoRole=true; $('roleWrap').classList.add('hidden'); showStep(1);
-      }else{
-        // 仍用下拉选择角色（更稳）
-        $('role').innerHTML='';
-        const opt0=document.createElement('option'); opt0.value=''; opt0.textContent='— 请选择 —';
-        $('role').appendChild(opt0);
-        conf.roles.forEach(r=>{
-          const opt=document.createElement('option'); opt.value=r.name; opt.textContent=r.name;
-          $('role').appendChild(opt);
-        });
-        showStep(0);
-      }
-
-      // 货币 chips
-      renderChips($('gridCurrency'), conf.currencies, (x)=>x, '');
-
-      // 大类 chips
-      const cats=Object.keys(conf.categories);
-      renderChips($('gridCategory'), cats, (x)=>x, '');
-
-      // 首次细类先空
-      $('gridSubcategory').innerHTML='';
-    }).withFailureHandler((err)=>{
-      setMsg(err && err.message ? err.message : '配置加载失败');
-    }).getConfig();
-  </script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,135 @@
+const $ = (id) => document.getElementById(id);
+const state = {
+  conf: null,
+  step: 0,
+  lastStep: 5,
+  sel: { role: '', currency: '', category: '', subcategory: '' }
+};
+
+function setMsg(text, ok = false) {
+  const el = $('msg');
+  el.textContent = text || '';
+  el.className = 'hint ' + (ok ? 'ok' : 'err');
+}
+
+// Generic chip renderer
+function renderChips(container, items, selected = '') {
+  container.innerHTML = '';
+  items.forEach(val => {
+    const div = document.createElement('div');
+    div.className = 'chip';
+    div.textContent = val;
+    div.dataset.value = val;
+    if (val === selected) div.dataset.selected = '1';
+    div.addEventListener('click', () => {
+      [...container.children].forEach(c => c.dataset.selected = '0');
+      div.dataset.selected = '1';
+    }, { passive: true });
+    container.appendChild(div);
+  });
+}
+
+function getSelected(container) {
+  const hit = [...container.children].find(c => c.dataset.selected === '1');
+  return hit ? hit.dataset.value : '';
+}
+
+function showStep(n) {
+  state.step = n;
+  document.querySelectorAll('.step').forEach(s => s.classList.add('hidden'));
+  const target = document.querySelector(`.step[data-step="${n}"]`);
+  if (target) target.classList.remove('hidden');
+  $('progress').textContent = `步骤 ${Math.min(n + 1, state.lastStep + 1)} / ${state.lastStep + 1}`;
+  $('btnPrev').disabled = (n === 0);
+  $('btnNext').textContent = (n === state.lastStep) ? '提交' : '下一步';
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function validateStep(n) {
+  if (n === 0) {
+    state.sel.role = getSelected($('gridRole'));
+    if (!state.sel.role) { setMsg('请选择角色'); return false; }
+    return true;
+  }
+  if (n === 1) {
+    state.sel.currency = getSelected($('gridCurrency'));
+    if (!state.sel.currency) { setMsg('请选择货币'); return false; }
+    return true;
+  }
+  if (n === 2) {
+    state.sel.category = getSelected($('gridCategory'));
+    if (!state.sel.category) { setMsg('请选择大类'); return false; }
+    return true;
+  }
+  if (n === 3) {
+    state.sel.subcategory = getSelected($('gridSubcategory'));
+    if (!state.sel.subcategory) { setMsg('请选择细类'); return false; }
+    return true;
+  }
+  if (n === 4) {
+    const a = Number($('amount').value);
+    if (!(a > 0)) { setMsg('金额需 > 0'); return false; }
+    return true;
+  }
+  return true;
+}
+
+function collectPayload() {
+  return {
+    role: state.sel.role,
+    currency: state.sel.currency,
+    category: state.sel.category,
+    subcategory: state.sel.subcategory,
+    amount: Number($('amount').value),
+    note: $('note').value.trim()
+  };
+}
+
+function submit() {
+  const payload = collectPayload();
+  $('btnNext').disabled = true; setMsg('');
+  google.script.run.withSuccessHandler(res => {
+    $('btnNext').disabled = false;
+    if (res && res.ok) {
+      setMsg(`已记录（行 ${res.row}）`, true);
+      $('amount').value = '';
+      $('note').value = '';
+      showStep(4);
+    } else setMsg('提交失败');
+  }).withFailureHandler(err => {
+    $('btnNext').disabled = false;
+    setMsg(err && err.message ? err.message : '提交失败');
+  }).recordTxn(payload);
+}
+
+// Next/Prev
+$('btnNext').addEventListener('click', () => {
+  setMsg('');
+  if (state.step === state.lastStep) {
+    if (validateStep(state.step)) submit();
+    return;
+  }
+  if (validateStep(state.step)) {
+    if (state.step === 2) {
+      const subs = (state.conf && state.conf.categories[state.sel.category]) || [];
+      renderChips($('gridSubcategory'), subs, '');
+    }
+    showStep(state.step + 1);
+  }
+});
+$('btnPrev').addEventListener('click', () => {
+  setMsg('');
+  if (state.step > 0) showStep(state.step - 1);
+});
+
+// Init
+google.script.run.withSuccessHandler(conf => {
+  state.conf = conf;
+  renderChips($('gridRole'), conf.roles.map(r => r.name), '');
+  renderChips($('gridCurrency'), conf.currencies, '');
+  renderChips($('gridCategory'), Object.keys(conf.categories), '');
+  $('gridSubcategory').innerHTML = '';
+  showStep(0);
+}).withFailureHandler(err => {
+  setMsg(err && err.message ? err.message : '配置加载失败');
+}).getConfig();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sheetledger",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Load Apps Script code
+const code = fs.readFileSync(path.join(__dirname, '..', 'Code.gs'), 'utf8');
+eval(code);
+
+class MockSheet {
+  constructor(values = []) {
+    this.values = values;
+  }
+  getDataRange() {
+    return { getValues: () => this.values };
+  }
+  appendRow(row) {
+    this.values.push(row);
+  }
+  getLastRow() {
+    return this.values.length;
+  }
+}
+
+class MockSpreadsheet {
+  constructor(sheets) {
+    this.sheets = sheets;
+  }
+  getSheetByName(name) {
+    return this.sheets[name];
+  }
+}
+
+function setupEnv() {
+  const sheets = {
+    Config_Roles: new MockSheet([
+      ['id', 'name', 'email'],
+      ['1', 'Alice', 'alice@example.com'],
+      ['2', 'Bob', 'bob@example.com']
+    ]),
+    Config_Currency: new MockSheet([
+      ['code'],
+      ['USD'],
+      ['CNY']
+    ]),
+    Config_Categories: new MockSheet([
+      ['cat', 'sub'],
+      ['Food', 'Dining'],
+      ['Food', 'Snack']
+    ]),
+    Transactions: new MockSheet([
+      ['timestamp', 'role', 'currency', 'category', 'subcategory', 'amount', 'note']
+    ])
+  };
+  global.SpreadsheetApp = {
+    getActive: () => new MockSpreadsheet(sheets)
+  };
+  return sheets;
+}
+
+test('getConfig parses sheets', () => {
+  setupEnv();
+  const conf = getConfig();
+  assert.deepStrictEqual(conf.roles[0], { id: '1', name: 'Alice', email: 'alice@example.com' });
+  assert.deepStrictEqual(conf.currencies, ['USD', 'CNY']);
+  assert.deepStrictEqual(conf.categories, { Food: ['Dining', 'Snack'] });
+});
+
+test('recordTxn appends row', () => {
+  const sheets = setupEnv();
+  const res = recordTxn({
+    role: 'Alice',
+    currency: 'USD',
+    category: 'Food',
+    subcategory: 'Dining',
+    amount: 10,
+    note: 'Test'
+  });
+  assert.ok(res.ok);
+  assert.strictEqual(sheets.Transactions.getLastRow(), 2);
+});
+
+test('recordTxn requires role', () => {
+  setupEnv();
+  assert.throws(() => recordTxn({
+    currency: 'USD',
+    category: 'Food',
+    subcategory: 'Dining',
+    amount: 5
+  }), /缺少 role/);
+});


### PR DESCRIPTION
## Summary
- require explicit role selection and drop automatic role detection
- move inline UI logic to `main.js` for easier maintenance
- add Node-based tests and ignore them during Apps Script deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b932d9f6588328af9a9c2e69abec61