### PR TITLE
Improve template, cache config, and expand backend tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,6 @@
     </div>
   </div>
 
-  <<?!= include('main'); ?>
+  <?!= include('main'); ?>
 </body>
 </html>

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -55,6 +55,7 @@ function setupEnv() {
   global.SpreadsheetApp = {
     getActive: () => new MockSpreadsheet(sheets)
   };
+  refreshConfig();
   return sheets;
 }
 
@@ -78,6 +79,13 @@ test('recordTxn appends row', () => {
   });
   assert.ok(res.ok);
   assert.strictEqual(sheets.Transactions.getLastRow(), 2);
+  const row = sheets.Transactions.values[1];
+  assert.strictEqual(row[1], 'Dining');
+  assert.strictEqual(row[2], 'Food');
+  assert.strictEqual(row[3], 10);
+  assert.strictEqual(row[4], 'Alice');
+  assert.strictEqual(row[5], 'USD');
+  assert.strictEqual(row[6], 'Test');
 });
 
 test('recordTxn requires role', () => {
@@ -88,4 +96,37 @@ test('recordTxn requires role', () => {
     subcategory: 'Dining',
     amount: 5
   }), /缺少 role/);
+});
+
+test('recordTxn rejects unknown currency', () => {
+  setupEnv();
+  assert.throws(() => recordTxn({
+    role: 'Alice',
+    currency: 'EUR',
+    category: 'Food',
+    subcategory: 'Dining',
+    amount: 5
+  }), /currency 不在配置中/);
+});
+
+test('recordTxn rejects unknown category', () => {
+  setupEnv();
+  assert.throws(() => recordTxn({
+    role: 'Alice',
+    currency: 'USD',
+    category: 'Travel',
+    subcategory: 'Flight',
+    amount: 5
+  }), /category 不在配置中/);
+});
+
+test('recordTxn rejects unknown subcategory', () => {
+  setupEnv();
+  assert.throws(() => recordTxn({
+    role: 'Alice',
+    currency: 'USD',
+    category: 'Food',
+    subcategory: 'Breakfast',
+    amount: 5
+  }), /subcategory 不在配置中/);
 });


### PR DESCRIPTION
## Summary
- fix extra template character in `index.html`
- cache configuration reads in `getConfig` and allow manual refresh
- expand backend tests for invalid inputs and verify appended row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94834016083288c90cf34ede1f8ea